### PR TITLE
Eliminate nonnull parameter 'pv' will evaluate to 'true' on first encounter error from clang

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,6 +2,8 @@
 
 use inc::Module::Install;
 
+use Config;
+
 name('Crypt-OpenSSL-PKCS12');
 license('perl');
 perl_version('5.005');
@@ -21,7 +23,12 @@ cc_inc_paths('/usr/include/openssl', '/usr/local/include/ssl', '/usr/local/ssl/i
 cc_lib_paths('/usr/lib', '/usr/local/lib', '/usr/local/ssl/lib');
 
 cc_lib_links('crypto');
-cc_optimize_flags('-O2 -g -Wall -Werror');
+
+if ($Config::Config{myuname} =~ /darwin/i) {
+  cc_optimize_flags('-O2 -g -Wall -Werror -Wno-error=pointer-bool-conversion');
+} else {
+  cc_optimize_flags('-O2 -g -Wall -Werror');
+}
 
 auto_install();
 WriteAll();


### PR DESCRIPTION
clang has changed behaviour and throws and error on bool conversion:

```
> make
Skip blib/lib/Crypt/OpenSSL/PKCS12.pm (unchanged)
Running Mkbootstrap for Crypt::OpenSSL::PKCS12 ()
chmod 644 "PKCS12.bs"
cc -c  -I/usr/include/openssl -I/usr/local/include/ssl -I/usr/local/ssl/include -fno-common -DPERL_DARWIN -fno-strict-aliasing -pipe -fstack-protector -O2 -g -Wall -Werror   -DVERSION=\"0.7\" -DXS_VERSION=\"0.7\"  "-I/Users/jonasbn/perl5/perlbrew/perls/perl-5.20.2/lib/5.20.2/darwin-2level/CORE"   PKCS12.c
In file included from PKCS12.xs:2:
In file included from /Users/jonasbn/perl5/perlbrew/perls/perl-5.20.2/lib/5.20.2/darwin-2level/CORE/perl.h:5199:
/Users/jonasbn/perl5/perlbrew/perls/perl-5.20.2/lib/5.20.2/darwin-2level/CORE/inline.h:311:9: error: nonnull parameter
      'pv' will evaluate to 'true' on first encounter [-Werror,-Wpointer-bool-conversion]
    if (pv && len > 1) {
        ^~ ~~
1 error generated.
make: *** [PKCS12.o] Error 1
```

This can be eliminated by turning the error into a warning, using:

`-Wno-error=pointer-bool-conversion`

This PR addresses issue #7 