### PR TITLE
Fixing Module::Install MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -14,6 +14,7 @@ inc/Module/Install.pm
 inc/Module/Install/Metadata.pm
 inc/Module/Install/Base.pm
 inc/Module/Install/Compiler.pm
+inc/Module/Install/External.pm
 inc/Module/Install/Makefile.pm
 inc/Module/Install/AutoInstall.pm
 inc/Module/Install/Include.pm


### PR DESCRIPTION
The Module::Install use was broken. The MANIFEST file, does not mention External,pm meaning the the C-compiler integration was not working:

"Unknown function is found at Makefile.PL"