### PR TITLE
Release candidate 0.8

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,24 @@
 Revision history for Perl extension Crypt::OpenSSL::PKCS12.
 
+0.8   Sun Nov 12 20:41:47 CET 2017
+
+    - Patch from jonasbn improving handling of C include paths
+
+    - Patch from jonasbn reinitializing inc/ and Module::Install integration
+
+    - Patch from Songmu adjusting use of paths and flags in Makeilfe.PL
+
+    - Patch from jonasbn adding inc/Module/Install/External.pm from Module::Install
+      missing from MANIFEST
+
+    - Patch from jonasbn for compability with required C libraries installed
+      via Homebrew on OSX
+
+    - Patch from jonasbn to address clang changes
+
+    - Patch from Christopher Hoskin enabling compability with OpenSSL 1.1.0 and
+      backwards compability with OpenSSL 1.0.2
+
 0.7   Fri Oct 24 06:16:43 PDT 2014
 	- Patch from Mikołaj Zalewski to fix C90 issue on CentOS.
 	- Patch from Darko Prelec to fix compile issue #2.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,10 +19,8 @@ test_requires 'Test::More' => '0.47';
 
 requires_external_cc();
 
-cc_inc_paths('/usr/local/opt/openssl/include', '/usr/include/openssl', '/usr/local/include/ssl', '/usr/local/ssl/include');
-cc_lib_paths('/usr/local/opt/openssl/lib', '/usr/lib', '/usr/local/lib', '/usr/local/ssl/lib');
-
-cc_lib_links('crypto');
+inc '-I/usr/local/opt/openssl/include -I/usr/include/openssl -I/usr/local/include/ssl -I/usr/local/ssl/include';
+libs '-L/usr/local/opt/openssl/lib -L/usr/lib -L/usr/local/lib -L/usr/local/ssl/lib -lcrypto -lssl';
 
 if ($^O ne 'darwin') {
     cc_optimize_flags('-O2 -g -Wall -Werror');

--- a/PKCS12.pm
+++ b/PKCS12.pm
@@ -5,7 +5,7 @@ use vars qw($VERSION @EXPORT_OK);
 use Exporter;
 use base qw(Exporter);
 
-$VERSION = '0.7';
+$VERSION = '0.8';
 
 @EXPORT_OK = qw(NOKEYS NOCERTS INFO CLCERTS CACERTS);
 


### PR DESCRIPTION
Hi @dsully 

In relation to my release contribution for Crypt::OpenSSL::X509 I have made a similar PR for Crypt::OpenSSL::PKCS12, do note that this PR does not pass the Travis check, the Travis check have been addressed in PR #16. 

This PR does however hold a cherry-pick from the mentioned branch, in order to get the test suite to pass on OSX. 

`$ git cherry-pick 3c627807dda03430f2d560adf7209b52cc5c36cb`

I can see that you have given me COMAINT on this distribution also, I am more than happy to help out, since we use your distributions in our systems at work 👍 

If you need more help with bug triage etc. on Github, just let me know.