### PR TITLE
Add . to @INC in Makefile.PL

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Crypt::OpenSSL::PKCS12.
 
+1.1  Tue Sep 4 0:0:0 CET 2018
+- Add Makefile.PL support for perl 5.26.0 and above which don't include . in @INC 
+
 1.0  Mon Mar 19 21:20:49 CET 2018
 
 - Re-release of 0.10, due to indexing issue with PAUSE/CPAN ref: #28

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 # $Id: Makefile.PL 10 1998-12-16 23:02:45Z daniel $
 
+BEGIN { push @INC, '.' unless $INC[-1] eq '.' }
 use inc::Module::Install;
 
 use Config;


### PR DESCRIPTION
# Description

Support for perl 5.26.0 and above in Makefile.PL

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- CentOS 7
- Crypt::OpenSSL::PKCS12 version 1.0
- 5.28.0
- OpenSSL version 1.0.2k-12.el7.x86_64
