### PR TITLE
Switch to using XSLoader

### DIFF
--- a/PKCS12.pm
+++ b/PKCS12.pm
@@ -9,15 +9,9 @@ $VERSION = '1.0';
 
 @EXPORT_OK = qw(NOKEYS NOCERTS INFO CLCERTS CACERTS);
 
-BOOT_XS: {
-  require DynaLoader;
+use XSLoader;
 
-  # DynaLoader calls dl_load_flags as a static method.
-  *dl_load_flags = DynaLoader->can('dl_load_flags');
-
-  do {__PACKAGE__->can('bootstrap') ||
-    \&DynaLoader::bootstrap}->(__PACKAGE__,$VERSION);
-}
+XSLoader::load 'Crypt::OpenSSL::PKCS12', $VERSION;
 
 END {
   __PACKAGE__->__PKCS12_cleanup();


### PR DESCRIPTION
# Description

The XSLoader interface is simpler and does less stuff so loads more quickly.
Perl 5.6.0 becomes the minimum version for this module though as a result

Fixes/addresses (If applicable) # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- CentOS 7.5
- Crypt::OpenSSL::PKCS12 version master
- Perl 5.28.0
- OpenSSL version 1.0.2k-12.el7.x86_64
