### PR TITLE
Drop use vars in favor of more modern our

### DIFF
--- a/PKCS12.pm
+++ b/PKCS12.pm
@@ -1,13 +1,12 @@
 package Crypt::OpenSSL::PKCS12;
 
 use strict;
-use vars qw($VERSION @EXPORT_OK);
 use Exporter;
-use base qw(Exporter);
 
-$VERSION = '1.0';
+our $VERSION = '1.0';
+our @ISA = qw(Exporter);
 
-@EXPORT_OK = qw(NOKEYS NOCERTS INFO CLCERTS CACERTS);
+our @EXPORT_OK = qw(NOKEYS NOCERTS INFO CLCERTS CACERTS);
 
 use XSLoader;
 


### PR DESCRIPTION
# Description

Since 5.6.0, our has replaced use vars. Not only is our more standard, but it has less of a memory profile. not to mention wibbly wobbly scope differences vars causes.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Centos 7
- Crypt::OpenSSL::PKCS12 version master
- Perl version 5.28.0
- OpenSSL version 1.0.2k-12.el7.x86_64

Please see the issue template for a more information on provided the requested information.

