### PR TITLE
Makefile cleanup

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 Revision history for Perl extension Crypt::OpenSSL::PKCS12.
 
+1.4  Sun Apr 11 16:23:54 CEST 2021
+
+- Addressed issue with homebrew path reported for Crypt::OpenSSL::X509
+  REF: https://github.com/dsully/perl-crypt-openssl-x509/issues/81
+
+  The pattern is the same in this distribution
+
 1.3  Thu Jun  4 21:39:30 CEST 2020
 
 - Maintenance release addressing the broken inc/ configuration pointed out in: RT:77784 by HMBRAND

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,8 +1,9 @@
 # $Id: Makefile.PL 10 1998-12-16 23:02:45Z daniel $
 
-BEGIN { push @INC, '.' unless $INC[-1] eq '.' }
+use lib '.';
 use inc::Module::Install;
 
+use File::Spec;
 use Config;
 
 name('Crypt-OpenSSL-PKCS12');
@@ -20,14 +21,19 @@ test_requires 'Test::More' => '0.47';
 
 requires_external_cc();
 
-inc '-I/usr/local/opt/openssl/include -I/usr/include/openssl -I/usr/local/include/ssl -I/usr/local/ssl/include';
-libs '-L/usr/local/opt/openssl/lib -L/usr/lib -L/usr/local/lib -L/usr/local/ssl/lib -lcrypto -lssl';
-
-if ($^O ne 'darwin') {
-    cc_optimize_flags('-O2 -g -Wall -Werror');
+if ($^O ne 'MSWin32' and my $prefix = `brew --prefix openssl 2>@{[File::Spec->devnull]}`) {
+  chomp $prefix;
+  inc "-I$prefix/include";
+  libs "-L$prefix/lib -lcrypto -lssl";
+} else {
+  inc '-I/usr/local/opt/openssl/include -I/usr/local/include/openssl -I/usr/include/openssl -I/usr/local/include/ssl -I/usr/local/ssl/include';
+  libs '-L/usr/local/opt/openssl/lib -L/usr/local/lib -L/usr/lib -L/usr/local/ssl/lib -lcrypto -lssl';
 }
-else {
+
+if ($Config::Config{myuname} =~ /darwin/i) {
     cc_optimize_flags('-O2 -g -Wall -Werror -Wno-deprecated-declarations');
+} else {
+    cc_optimize_flags('-O2 -g -Wall -Werror');
 }
 
 auto_install();

--- a/PKCS12.pm
+++ b/PKCS12.pm
@@ -3,7 +3,7 @@ package Crypt::OpenSSL::PKCS12;
 use strict;
 use Exporter;
 
-our $VERSION = '1.3';
+our $VERSION = '1.4';
 our @ISA = qw(Exporter);
 
 our @EXPORT_OK = qw(NOKEYS NOCERTS INFO CLCERTS CACERTS);
@@ -117,7 +117,7 @@ Dan Sully, E<lt>daniel@cpan.orgE<gt>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2004-2018 by Dan Sully
+Copyright 2004-2021 by Dan Sully
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.8 or,

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Crypt/OpenSSL/PKCS12 version 1.2
+Crypt/OpenSSL/PKCS12 version 1.4
 ===============================
 
 The README is used to introduce the module and provide instructions on
@@ -31,7 +31,7 @@ COPYRIGHT AND LICENCE
 
 Put the correct copyright and licence information here.
 
-Copyright (C) 2004-2018 Dan Sully
+Copyright (C) 2004-2021 Dan Sully
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.


### PR DESCRIPTION
# Description

This addresses a potential issue with the new structure of homebrew directories, observed and fixed in:

dsully/perl-crypt-openssl-x509#81

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

## Test / Development Platform Information

- Operating system and version

```
Darwin hoarfrost 19.6.0 Darwin Kernel Version 19.6.0: Tue Jan 12 22:13:05 PST 2021; root:xnu-6153.141.16~1/RELEASE_X86_64 x86_64
```

- Perl version

```
This is perl 5, version 32, subversion 0 (v5.32.0) built for darwin-2level
(with 1 registered patch, see perl -V for more detail)
```

- OpenSSL version

```
OpenSSL 1.1.1i  8 Dec 2020
```
