### PR TITLE
Fix string length calculation in new_from_string()

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -49,4 +49,4 @@ jobs:
           curl -sL https://cpanmin.us/ | perl - -nq --with-develop --installdeps -v .
           perl Makefile.PL
           make
-          make test
+          make test TEST_VERBOSE=1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,4 +35,4 @@ jobs:
           curl -sL https://cpanmin.us/ | perl - -nq --with-develop --installdeps -v .
           perl Makefile.PL
           make
-          make test
+          make test TEST_VERBOSE=1

--- a/.github/workflows/msys2-mingw.yml
+++ b/.github/workflows/msys2-mingw.yml
@@ -48,4 +48,4 @@ jobs:
         run: |
           curl -Uri https://cpanmin.us/ | perl - -nq --with-develop --installdeps -v .
           make
-          make test
+          make test TEST_VERBOSE=1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,5 +39,5 @@ jobs:
           curl -sL https://cpanmin.us/ | perl - -nq --with-develop --installdeps -v .
           perl Makefile.PL
           gmake
-          gmake test
+          gmake test TEST_VERBOSE=1
 

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -374,7 +374,7 @@ new_from_string(class, string)
   if (!str_ptr || !str_len) croak("PKCS12_new_from: No string or file was passed.");
 
   if (ix == 1) {
-    bio = BIO_new_file(str_ptr, "r");
+    bio = BIO_new_file(str_ptr, "rb");
   } else {
     bio = BIO_new_mem_buf(str_ptr, str_len);
   }

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -356,9 +356,9 @@ new_from_string(class, string)
     if (ix == 1) {
       /* We are not looking up the SV's UTF8 bit because BIO_new_file() accepts
        * filename like syscall fopen() which mainly may accept octet sequences
-       * for UTF-8 in C char*. That's what we get from using SvPV_nolen. Also,
-       * using SvPV_nolen is not a bug if ASCII input is only allowed. */
-      str_ptr = SvPV_nolen(string);
+       * for UTF-8 in C char*. That's what we get from using SvPV(). Also,
+       * using SvPV() is not a bug if ASCII input is only allowed. */
+      str_ptr = SvPV(string, str_len);
     } else {
       /* To avoid encoding mess, caller is not allowed to provide octets from
        * UTF-8 encoded strings. BIO_new_mem_buf() needs octet input only. */

--- a/t/pkcs12-string.t
+++ b/t/pkcs12-string.t
@@ -1,0 +1,122 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+use Test::More tests => 29;
+use File::Spec::Functions qw(:ALL);
+use Data::Dumper;
+
+BEGIN { use_ok('Crypt::OpenSSL::PKCS12') };
+
+{
+    my $certdata = "тест";
+    is length $certdata, 8;
+    utf8::decode($certdata);
+    is length $certdata, 4;
+    local $@;
+    eval {
+        my $pkcs12 = Crypt::OpenSSL::PKCS12->new_from_string($certdata);
+    };
+
+    my $ok = $@ =~ /Source string must not be UTF-8 encoded/i;
+    ok $ok, 'utf8 string refused new_from_string()';
+}
+
+{
+    use utf8;
+    my $certdata = "тест";
+    is length $certdata, 4;
+    local $@;
+    eval {
+        my $pkcs12 = Crypt::OpenSSL::PKCS12->new_from_string($certdata);
+    };
+
+    my $ok = $@ =~ /Source string must not be UTF-8 encoded/i;
+    ok $ok, 'utf8 string refused in new_from_string()';
+}
+
+my $base   = 'certs';
+my $pass   = 'testing';
+
+my $certfile = catdir($base, 'test.p12');
+
+diag("Attempting to read certificate string from file $certfile");
+
+# first, make argument test
+my @argtest = (
+    [],    0, # 0 is for invalid argument type
+    {},    0,
+    undef, 0,
+    \ "s", 0,
+    0,     1, # 1 is for valid argument type
+    0.01,  1,
+    "str", 1,
+);
+
+for (my $i = 0; $i < @argtest; $i += 2) {
+    my ($arg, $arg_ok_expected) = ($argtest[$i], $argtest[$i + 1]);
+    eval { Crypt::OpenSSL::PKCS12->new_from_string($arg) };
+    unless ($arg_ok_expected) {
+        ok(!!($@ =~ /Invalid Perl type/));
+    } else {
+        # ignore SSL error; only argument type is for checking
+        pass;
+    }
+}
+
+# read file to string in Perl way
+ok(open my $fh, '<', $certfile);
+
+ok(binmode $fh);
+
+my $certdata = do { undef $/; <$fh> };
+
+ok(length $certdata);
+
+ok(close $fh);
+
+# make PKCS12 object from string
+my $pkcs12 = Crypt::OpenSSL::PKCS12->new_from_string($certdata);
+
+# run below code that is completely taken from the test pkcs12.t
+ok($pkcs12, 'PKCS object created');
+
+my $pemcert = $pkcs12->certificate($pass);
+
+ok($pemcert, 'PEM certificate created');
+
+my $pemkey = $pkcs12->private_key($pass);
+
+ok($pemkey, 'Asserting PEM key');
+
+ok($pkcs12->mac_ok($pass), 'Asserting mac');
+
+ok($pkcs12->as_string, 'Asserting PKCS12 as string');
+
+# try changing the password
+ok($pkcs12->changepass($pass, 'foo'), 'Changing password');
+
+ok($pkcs12->mac_ok('foo'), 'Reasserting mac');
+
+ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+
+# Try creating a PKCS12 file.
+my $outfile = catdir($base, 'out.p12');
+
+ok($pkcs12->create(
+	catdir($base, 'test-cert.pem'),
+	catdir($base, 'test-key.pem'),
+	$pass,
+	$outfile,
+	'Friendly Name'
+), 'Testing create based on PKCS12');
+
+ok(-f $outfile);
+
+my $created = Crypt::OpenSSL::PKCS12->new_from_file($outfile);
+
+ok($created);
+
+ok($created->mac_ok($pass), 'Reasserting new mac');
+
+unlink $outfile;


### PR DESCRIPTION
Crypt::OpenSSL::PKCS12::new_from_string() is based on OpenSSL function
BIO_new_mem_buf().

BIO_new_mem_buf() creates a memory BIO using len bytes of data at buf,
if len is -1 then the buf is assumed to be nul terminated and its length
is determined by strlen.

PKCS12 file data is not a nul terminated string usually. It may contain
nul bytes in the middle of a buf. That's why new_from_string() usually
provides truncated string/buf to BIO_new_mem_buf().

Just use SvPV() instead of strlen() to calculate Perl string length for
BIO_new_mem_buf().

# Description

Please include a summary of the proposed improvement or addressed issue.

Fixes/addresses (If applicable) # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version: Ubuntu 16.04 x86_64
- Crypt::OpenSSL::PKCS12 version 1.7
- Perl version version 22, subversion 1 (v5.22.1) built for x86_64-linux-gnu-thread-multi
- OpenSSL version 1.0.2g-1ubuntu4.19
