### PR TITLE
New method create_as_string to create a PKCS12 string

### DIFF
--- a/PKCS12.pm
+++ b/PKCS12.pm
@@ -90,6 +90,12 @@ Create a new PKCS12 certificate. $cert & $key may either be strings or filenames
 
 $friendly_name is optional.
 
+=item * create_as_string( $cert, $key, $pass, $friendly_name )
+
+Create a new PKCS12 certificate string. $cert & $key may either be strings or filenames.
+
+$friendly_name is optional.
+
 =back
 
 =head1 EXPORT

--- a/t/pkcs12.t
+++ b/t/pkcs12.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-use Test::More tests => 13;
+use Test::More tests => 16;
 use File::Spec::Functions qw(:ALL);
 use Data::Dumper;
 
@@ -58,3 +58,19 @@ ok($created);
 ok($created->mac_ok($pass), 'Reasserting new mac');
 
 unlink $outfile;
+
+my $pksc12_data = $pkcs12->create_as_string(
+	catdir($base, 'test-cert.pem'),
+	catdir($base, 'test-key.pem'),
+	$pass,
+	"Friendly Name"
+);
+
+ok($pksc12_data);
+
+$created = Crypt::OpenSSL::PKCS12->new_from_string($pksc12_data);
+
+ok($created);
+
+ok($created->mac_ok($pass));
+


### PR DESCRIPTION
# Description

New method create_as_string

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system Centos 8
- Crypt::OpenSSL::PKCS12 version 1.7
- Perl version v5.26.3
- OpenSSL version 1.1.1g



