### PR TITLE
Installs OpenSSL version 1, default is version 3

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,6 +20,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: install openssl
+        run: |
+          brew install openssl@1.1
 
       # REF: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md (see link above, at the time of writing we get Perl 5.34.0 with macOS 10.15)
       - name: Set up Perl


### PR DESCRIPTION
The macOS-latest foundation uses Homebrew and the OpenSSL version 3 is apparently also available even though the documentation says version 1, we currently only support version 1.

REF: 

- https://github.com/actions/runner-images
- https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
