### PR TITLE
Fixes #45 missing functions on older openSSL versions

### DIFF
--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -18,6 +18,9 @@
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define PKCS12_SAFEBAG_get0_p8inf(o) ((o)->value.keybag)
 #define PKCS12_SAFEBAG_get0_attr PKCS12_get_attr
+#define PKCS12_SAFEBAG_get_bag_nid M_PKCS12_cert_bag_type
+#define PKCS12_SAFEBAG_get_nid M_PKCS12_bag_type
+#define PKCS12_SAFEBAG_get1_cert PKCS12_certbag2x509
 #define CONST_PKCS8_PRIV_KEY_INFO PKCS8_PRIV_KEY_INFO
 #else
 #define CONST_PKCS8_PRIV_KEY_INFO const PKCS8_PRIV_KEY_INFO
@@ -181,10 +184,14 @@ int dump_certs_pkeys_bag (BIO *bio, PKCS12_SAFEBAG *bag, char *pass, int passlen
   X509 *x509;
   PKCS8_PRIV_KEY_INFO *p8;
   CONST_PKCS8_PRIV_KEY_INFO *p8c;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
   const STACK_OF(X509_ATTRIBUTE) *attrs;
+#endif
   int ret = 0;
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
   attrs = PKCS12_SAFEBAG_get0_attrs(bag);
+#endif
 
 #ifndef OPENSSL_NO_DES
   EVP_CIPHER *default_enc = (EVP_CIPHER *)EVP_des_ede3_cbc();


### PR DESCRIPTION
# Description

Define older functions for the same functionality in older versions related to TRIAL version 1.10 cpan failures

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version CentOS Linux release 7.5.1804 (Core) 
- Crypt::OpenSSL::PKCS12 version 1.10
- Perl version 5.14.4
- OpenSSL version OpenSSL 1.0.2k-fips  26 Jan 2017

Please see the issue template for a more information on provided the requested information.

