### PR TITLE
set LDDLFLAGS by default in case library is installed elsewhere

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -50,8 +50,9 @@ if ($Config{myuname} =~ /sunos|solaris/i) {
     $args{LIBS} = [openssl_lib_paths() . ' -leay32'];
   }
 } elsif ($Config{myuname} =~ /darwin/ ) {
-  $args{LDDLFLAGS} = openssl_lib_paths() . " " . $Config{lddlflags};
+  $args{LDDLFLAGS} = openssl_lib_paths() . ' ' . $Config{lddlflags};
 } else {
+  $args{LDDLFLAGS} = openssl_lib_paths() . ' ' . $Config{lddlflags};
   $args{OPTIMIZE} = $cc_option_flags;
 }
 

--- a/maint/Makefile_header.PL
+++ b/maint/Makefile_header.PL
@@ -41,7 +41,8 @@ if ($Config{myuname} =~ /sunos|solaris/i) {
     $args{LIBS} = [openssl_lib_paths() . ' -leay32'];
   }
 } elsif ($Config{myuname} =~ /darwin/ ) {
-  $args{LDDLFLAGS} = openssl_lib_paths() . " " . $Config{lddlflags};
+  $args{LDDLFLAGS} = openssl_lib_paths() . ' ' . $Config{lddlflags};
 } else {
+  $args{LDDLFLAGS} = openssl_lib_paths() . ' ' . $Config{lddlflags};
   $args{OPTIMIZE} = $cc_option_flags;
 }


### PR DESCRIPTION
# Description

This sets LDDLFLAGS by default in case library is installed elsewhere

I was trouble shooting a HPUX issre where OpenSSL 1.1.1w  11 Sep 2023 in a non standard location and this was needed.  It should be required by default to catch cases when Crypt::OpenSSL::Guess finds another openssl version that is not installed by default

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version
- Crypt::OpenSSL::PKCS12 version  OpenSSL 1.1.1w
- Perl version: 5.26.2
- OpenSSL version HP UX

Ubuntu 24:04 and all the github actions pass

