### PR TITLE
add a `ca_certificate` method

### DIFF
--- a/PKCS12.pm
+++ b/PKCS12.pm
@@ -85,6 +85,10 @@ Create a new Crypt::OpenSSL::PKCS12 instance.
 
 Get the Base64 representation of the certificate.
 
+=item * ca_certificate( [C<$pass>] )
+
+Get the Base64 representation of the CA certificate chain.
+
 =item * private_key( [C<$pass>] )
 
 Get the Base64 representation of the private key.

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -1252,6 +1252,29 @@ certificate(pkcs12, pwd = "")
   RETVAL
 
 SV*
+ca_certificate(pkcs12, pwd = "")
+  Crypt::OpenSSL::PKCS12 pkcs12
+  char *pwd
+
+  PREINIT:
+  BIO *bio;
+  STACK_OF(PKCS7) *asafes = NULL;
+
+  CODE:
+
+  CHECK_OPEN_SSL(bio = BIO_new(BIO_s_mem()));
+
+  if ((asafes = PKCS12_unpack_authsafes(pkcs12)) == NULL)
+        RETVAL = newSVpvn("",0);
+
+  dump_certs_keys_p12(aTHX_ bio, pkcs12, pwd, strlen(pwd), CACERTS|NOKEYS, NULL, NULL);
+
+  RETVAL = extractBioString(aTHX_ bio);
+
+  OUTPUT:
+  RETVAL
+
+SV*
 private_key(pkcs12, pwd = "")
   Crypt::OpenSSL::PKCS12 pkcs12
   char *pwd

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ This distribution implements a subset of OpenSSL's PKCS12 API.
 
     Get the Base64 representation of the certificate.
 
+- ca\_certificate( \[`$pass`\] )
+
+    Get the Base64 representation of the CA certificate chain.
+
 - private\_key( \[`$pass`\] )
 
     Get the Base64 representation of the private key.

--- a/t/pkcs12.t
+++ b/t/pkcs12.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-use Test::More tests => 16;
+use Test::More tests => 17;
 use File::Spec::Functions qw(:ALL);
 use Data::Dumper;
 use Crypt::OpenSSL::Guess;
@@ -30,6 +30,10 @@ ok($pkcs12, 'PKCS object created');
 my $pemcert = $pkcs12->certificate($pass);
 
 ok($pemcert, 'PEM certificate created');
+
+my $cacert = $pkcs12->ca_certificate($pass);
+
+ok($cacert, 'CA certificate created');
 
 my $pemkey = $pkcs12->private_key($pass);
 


### PR DESCRIPTION
# Description

This adds a `ca_certificate` method, which is pretty much identical to `certificate` or `private_key`, but returns the certificate chain if present.

Partly for completeness, partly because my employer needed it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Gentoo Linux & Ubuntu 16.04 & Ubuntu 22.04
- Crypt::OpenSSL::PKCS12 1.93
- Perl 5.40 & 5.30
- OpenSSL 3.0.15 & 1.0.2g & 3.0.2
