### PR TITLE
fix: OpenSSL 4.0 — use ASN1_STRING accessors instead of direct struct member access

### DIFF
--- a/.claude/skills/release-checklist/SKILL.md
+++ b/.claude/skills/release-checklist/SKILL.md
@@ -14,9 +14,9 @@ Run through the release checklist for this distribution. Check each step and rep
    perl Makefile.PL && make && prove -lr -l -b t
    ```
 
-4. **Author tests** — run with strict compiler warnings enabled:
+4. **Author and Release tests** — run with strict compiler warnings enabled:
    ```
-   AUTHOR_TESTING=1 perl Makefile.PL && make
+   AUTHOR_TESTING=1 RELEASE_TESTING=1 carton exec -- dzil test
    ```
 
 5. **Dist build** — build the distribution tarball via Dist::Zilla:
@@ -32,7 +32,7 @@ Run through the release checklist for this distribution. Check each step and rep
 
 7. **Upload** — upload to CPAN:
    ```
-   dzil release
+   carton exec -- dzil release
    ```
    or manually via `cpan-upload Crypt-OpenSSL-PKCS12-<VERSION>.tar.gz`.
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Crypt-OpenSSL-PKCS12-*.*/
 804cf94a94dd9091525be7b36b57ef4006c5b282.patch
 PKCS12.c
 .claude/settings.local.json
+.env

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -840,7 +840,7 @@ int print_attribs(pTHX_ BIO *out, CONST_STACK_OF(X509_ATTRIBUTE) *attrlst,
                 croak("unable to add MAC to the hash");
             }
 
-            BIO_set_close(attr_bio, BIO_CLOSE);
+            (void)BIO_set_close(attr_bio, BIO_CLOSE);
             BIO_free(attr_bio);
           }
           Safefree(attribute_value);

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -826,20 +826,21 @@ int print_attribs(pTHX_ BIO *out, CONST_STACK_OF(X509_ATTRIBUTE) *attrlst,
             }
           } else {
             BIO *attr_bio;
-            BUF_MEM* bptr;
+            char *attr_key = NULL;
+            long attr_key_len;
 
             CHECK_OPEN_SSL(attr_bio = BIO_new(BIO_s_mem()));
             i2a_ASN1_OBJECT(attr_bio, attr_obj);
 
             CHECK_OPEN_SSL(BIO_flush(attr_bio) == 1);
-            BIO_get_mem_ptr(attr_bio, &bptr);
+            attr_key_len = BIO_get_mem_data(attr_bio, &attr_key);
 
-            if (bptr->length > 0) {
-              if((hv_store(bag_hv,  bptr->data, bptr->length, newSVpvn(attribute_value, strlen(attribute_value)), 0)) == NULL)
+            if (attr_key_len > 0) {
+              if((hv_store(bag_hv, attr_key, (I32)attr_key_len, newSVpvn(attribute_value, strlen(attribute_value)), 0)) == NULL)
                 croak("unable to add MAC to the hash");
             }
 
-            CHECK_OPEN_SSL(BIO_set_close(attr_bio, BIO_CLOSE) == 1);
+            BIO_set_close(attr_bio, BIO_CLOSE);
             BIO_free(attr_bio);
           }
           Safefree(attribute_value);

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -762,7 +762,7 @@ int print_attribs(pTHX_ BIO *out, CONST_STACK_OF(X509_ATTRIBUTE) *attrlst,
                   const char *name, HV * hash)
 {
   X509_ATTRIBUTE *attr;
-  ASN1_TYPE *av;
+  CONST_ASN1_TYPE *av;
   int i, j, attr_nid;
   AV * bags_av = newAV();
   if (!attrlst) {
@@ -789,7 +789,7 @@ int print_attribs(pTHX_ BIO *out, CONST_STACK_OF(X509_ATTRIBUTE) *attrlst,
 
   HV * bag_hv = newHV();
   for (i = 0; i < sk_X509_ATTRIBUTE_num(attrlst); i++) {
-    ASN1_OBJECT *attr_obj;
+    CONST_ASN1_OBJECT *attr_obj;
     attr = sk_X509_ATTRIBUTE_value(attrlst, i);
     attr_obj = X509_ATTRIBUTE_get0_object(attr);
     attr_nid = OBJ_obj2nid(attr_obj);

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -63,7 +63,7 @@ int dump_certs_pkeys_bags(pTHX_ BIO *out, CONST_STACK_OF(PKCS12_SAFEBAG) *bags,
 static int alg_print(pTHX_ BIO *bio, CONST_X509_ALGOR *alg, HV* hash);
 void print_attribute(pTHX_ BIO *out, CONST_ASN1_TYPE *av, char **value);
 int print_attribs(pTHX_ BIO *out, CONST_STACK_OF(X509_ATTRIBUTE) *attrlst, const char *name, HV *hash);
-void hex_prin(BIO *out, unsigned char *buf, int len);
+void hex_prin(BIO *out, const unsigned char *buf, int len);
 void dump_cert_text(BIO *out, X509 *x);
 SV * get_cert_subject_name(pTHX_ X509 *x);
 SV * get_cert_issuer_name(pTHX_ X509 *x);
@@ -632,7 +632,7 @@ SV * get_cert_issuer_name(pTHX_ X509 *x)
   return sv;
 }
 
-void get_hex(char *out, unsigned char *buf, int len)
+void get_hex(char *out, const unsigned char *buf, int len)
 {
   int i;
   for (i = 0; i < len; i++) {
@@ -644,7 +644,7 @@ void get_hex(char *out, unsigned char *buf, int len)
   *out = '\0';
 }
 
-void hex_prin(BIO *out, unsigned char *buf, int len)
+void hex_prin(BIO *out, const unsigned char *buf, int len)
 {
   int i;
   for (i = 0; i < len; i++)
@@ -700,7 +700,7 @@ void print_attribute(pTHX_ BIO *out, CONST_ASN1_TYPE *av, char **attribute)
         memcpy(*attribute, ASN1_STRING_get0_data(av->value.utf8string), (size_t)length);
       (*attribute)[length] = '\0';
     } else {
-      BIO_printf(out, "%.*s\n", length, ASN1_STRING_get0_data(av->value.utf8string));
+      BIO_printf(out, "%.*s\n", length, (const char *)ASN1_STRING_get0_data(av->value.utf8string));
     }
     break;
 
@@ -710,9 +710,9 @@ void print_attribute(pTHX_ BIO *out, CONST_ASN1_TYPE *av, char **attribute)
       if (length < 0 || length > INT_MAX / 4)
         croak("OCTET STRING attribute length out of range (got %d)", length);
       Renew(*attribute, (size_t)length * 4 + 1, char);
-      get_hex(*attribute, (unsigned char *)ASN1_STRING_get0_data(av->value.octet_string), length);
+      get_hex(*attribute, ASN1_STRING_get0_data(av->value.octet_string), length);
     } else {
-      hex_prin(out, (unsigned char *)ASN1_STRING_get0_data(av->value.octet_string), length);
+      hex_prin(out, ASN1_STRING_get0_data(av->value.octet_string), length);
       BIO_printf(out, "\n");
     }
     break;
@@ -723,9 +723,9 @@ void print_attribute(pTHX_ BIO *out, CONST_ASN1_TYPE *av, char **attribute)
       if (length < 0 || length > INT_MAX / 4)
         croak("BIT STRING attribute length out of range (got %d)", length);
       Renew(*attribute, (size_t)length * 4 + 1, char);
-      get_hex(*attribute, (unsigned char *)ASN1_STRING_get0_data(av->value.bit_string), length);
+      get_hex(*attribute, ASN1_STRING_get0_data(av->value.bit_string), length);
     } else {
-      hex_prin(out, (unsigned char *)ASN1_STRING_get0_data(av->value.bit_string), length);
+      hex_prin(out, ASN1_STRING_get0_data(av->value.bit_string), length);
       BIO_printf(out, "\n");
     }
     break;
@@ -822,7 +822,7 @@ int print_attribs(pTHX_ BIO *out, CONST_STACK_OF(X509_ATTRIBUTE) *attrlst,
             attribute_id = OBJ_nid2ln(attr_nid);
             if (attribute_id) {
               if((hv_store(bag_hv, attribute_id, strlen(attribute_id), newSVpvn(attribute_value, strlen(attribute_value)), 0)) == NULL)
-                croak("unable to add MAC to the hash");
+                croak("unable to store attribute in hash");
             }
           } else {
             BIO *attr_bio;
@@ -837,7 +837,7 @@ int print_attribs(pTHX_ BIO *out, CONST_STACK_OF(X509_ATTRIBUTE) *attrlst,
 
             if (attr_key_len > 0) {
               if((hv_store(bag_hv, attr_key, (I32)attr_key_len, newSVpvn(attribute_value, strlen(attribute_value)), 0)) == NULL)
-                croak("unable to add MAC to the hash");
+                croak("unable to store attribute in hash");
             }
 
             (void)BIO_set_close(attr_bio, BIO_CLOSE);

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -42,6 +42,7 @@ OSSL_PROVIDER *deflt    = NULL;
 #define CONST_ASN1_OBJECT ASN1_OBJECT
 #define CONST_ASN1_OCTET_STRING ASN1_OCTET_STRING
 #define CONST_VOID void
+#define ASN1_STRING_get0_data(x) ((const unsigned char *)ASN1_STRING_data(x))
 #else
 #define CONST_PKCS8_PRIV_KEY_INFO const PKCS8_PRIV_KEY_INFO
 #define CONST_X509_ALGOR const X509_ALGOR

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -663,10 +663,10 @@ void print_attribute(pTHX_ BIO *out, CONST_ASN1_TYPE *av, char **attribute)
   */
   switch (av->type) {
   case V_ASN1_BMPSTRING:
-    length = av->value.bmpstring->length;
+    length = ASN1_STRING_length(av->value.bmpstring);
     if (length < 0 || length > (INT_MAX - 1))
       croak("BMPSTRING attribute length out of range (got %d)", length);
-    value = OPENSSL_uni2asc(av->value.bmpstring->data, length);
+    value = OPENSSL_uni2asc(ASN1_STRING_get0_data(av->value.bmpstring), length);
     /* Defensive: OPENSSL_uni2asc returns NULL on allocation failure, and on
        an odd-length BMPSTRING. Guard before either branch dereferences it:
        the else branch below passes value to BIO_printf. */
@@ -691,41 +691,41 @@ void print_attribute(pTHX_ BIO *out, CONST_ASN1_TYPE *av, char **attribute)
     break;
 
   case V_ASN1_UTF8STRING:
-    length = av->value.utf8string->length;
+    length = ASN1_STRING_length(av->value.utf8string);
     if(*attribute != NULL) {
       if (length < 0 || length > (INT_MAX - 1))
         croak("UTF8STRING attribute length out of range (got %d)", length);
       Renew(*attribute, (size_t)length + 1, char);
       if (length)
-        memcpy(*attribute, av->value.utf8string->data, (size_t)length);
+        memcpy(*attribute, ASN1_STRING_get0_data(av->value.utf8string), (size_t)length);
       (*attribute)[length] = '\0';
     } else {
-      BIO_printf(out, "%.*s\n", length, av->value.utf8string->data);
+      BIO_printf(out, "%.*s\n", length, ASN1_STRING_get0_data(av->value.utf8string));
     }
     break;
 
   case V_ASN1_OCTET_STRING:
-    length = av->value.octet_string->length;
+    length = ASN1_STRING_length(av->value.octet_string);
     if(*attribute != NULL) {
       if (length < 0 || length > INT_MAX / 4)
         croak("OCTET STRING attribute length out of range (got %d)", length);
       Renew(*attribute, (size_t)length * 4 + 1, char);
-      get_hex(*attribute, av->value.octet_string->data, length);
+      get_hex(*attribute, (unsigned char *)ASN1_STRING_get0_data(av->value.octet_string), length);
     } else {
-      hex_prin(out, av->value.octet_string->data, length);
+      hex_prin(out, (unsigned char *)ASN1_STRING_get0_data(av->value.octet_string), length);
       BIO_printf(out, "\n");
     }
     break;
 
   case V_ASN1_BIT_STRING:
-    length = av->value.bit_string->length;
+    length = ASN1_STRING_length(av->value.bit_string);
     if(*attribute != NULL) {
       if (length < 0 || length > INT_MAX / 4)
         croak("BIT STRING attribute length out of range (got %d)", length);
       Renew(*attribute, (size_t)length * 4 + 1, char);
-      get_hex(*attribute, av->value.bit_string->data, length);
+      get_hex(*attribute, (unsigned char *)ASN1_STRING_get0_data(av->value.bit_string), length);
     } else {
-      hex_prin(out, av->value.bit_string->data, length);
+      hex_prin(out, (unsigned char *)ASN1_STRING_get0_data(av->value.bit_string), length);
       BIO_printf(out, "\n");
     }
     break;

--- a/docs/superpowers/plans/2026-06-16-openssl-4-opaque-asn1-fix.md
+++ b/docs/superpowers/plans/2026-06-16-openssl-4-opaque-asn1-fix.md
@@ -1,0 +1,450 @@
+# OpenSSL 4.0 Opaque ASN1 Struct Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `PKCS12.xs` to compile under OpenSSL 4.0, which made `asn1_string_st` (the backing struct for `ASN1_BMPSTRING`, `ASN1_UTF8STRING`, `ASN1_OCTET_STRING`, `ASN1_BIT_STRING`) opaque, breaking direct `->data` / `->length` member access.
+
+**Architecture:** Replace all direct struct-member dereferences in `print_attribute()` with the public accessor API (`ASN1_STRING_length()`, `ASN1_STRING_get0_data()`). Add a compat macro for `ASN1_STRING_get0_data` in the existing OpenSSL < 1.1.0 guard block so the same code compiles across OpenSSL 1.0, 1.1, 3.x, and 4.0. Also replace the direct `BUF_MEM` member access (`bptr->length`, `bptr->data`) in `print_attribs()` with `BIO_get_mem_data()`, which may become opaque in a future OpenSSL release and is the documented way to query a mem-BIO.
+
+**Tech Stack:** C / Perl XS, OpenSSL (1.0 – 4.0), `ppport.h` (Devel::PPPort), Dist::Zilla, `prove`
+
+---
+
+## Context
+
+- **Issue:** GitHub issue #60 — "Build failure with OpenSSL 4.0" (Debian bug #1138300)
+- **Branch to create:** `fix/openssl-4-opaque-asn1`
+- **Files to change:** `PKCS12.xs` only
+- **No new test files needed:** existing tests (`pkcs12-info-arbitrary-bag-attributes.t`, `pkcs12-info-utf8string-attribute.t`, `pkcs12-info-cve-2026-8507.t`, `pkcs12-info-le_1.1.t`) already exercise every changed code path and act as regression guards.
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|--------------|
+| `PKCS12.xs` | Modify | Add `ASN1_STRING_get0_data` compat macro; replace 10 direct struct-member dereferences in `print_attribute()` and 2 in `print_attribs()` |
+
+---
+
+## Task 1: Create the working branch
+
+**Files:**
+- (git only — no source edits)
+
+- [ ] **Step 1: Create and switch to the fix branch**
+
+```bash
+git checkout -b fix/openssl-4-opaque-asn1
+```
+
+Expected output: `Switched to a new branch 'fix/openssl-4-opaque-asn1'`
+
+- [ ] **Step 2: Confirm the branch is active**
+
+```bash
+git branch --show-current
+```
+
+Expected output: `fix/openssl-4-opaque-asn1`
+
+---
+
+## Task 2: Verify the tests pass on the current codebase (baseline)
+
+**Files:**
+- (no edits — this is a pre-flight check)
+
+- [ ] **Step 1: Build**
+
+```bash
+perl Makefile.PL && make
+```
+
+Expected: no errors; `make` produces `blib/`.
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+prove -lr -l -b -I inc t
+```
+
+Expected: all tests pass. Note the count so you can confirm it doesn't shrink after the fix.
+
+---
+
+## Task 3: Add `ASN1_STRING_get0_data` compat macro for OpenSSL < 1.1.0
+
+**Files:**
+- Modify: `PKCS12.xs:25-56` (the existing `#if OPENSSL_VERSION_NUMBER < 0x10100000L` compat block)
+
+**Why this is needed:** `ASN1_STRING_get0_data()` was introduced in OpenSSL 1.1.0. On OpenSSL < 1.1.0 the equivalent is `ASN1_STRING_data()` (non-const, but that is fine since the older API predates the const annotation). Adding the macro here keeps every fix in Task 4 unconditionally readable — no per-call `#ifdef`.
+
+- [ ] **Step 1: Open `PKCS12.xs` and locate the compat block**
+
+The block starts at line 25:
+```c
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+```
+It ends around line 44 with:
+```c
+#define CONST_VOID void
+```
+
+- [ ] **Step 2: Add the compat macro inside the `< 0x10100000L` branch**
+
+Find the existing line:
+```c
+#define CONST_VOID void
+```
+
+Add the new macro immediately after it, still inside the `#if` block:
+```c
+#define CONST_VOID void
+#define ASN1_STRING_get0_data(x) ((const unsigned char *)ASN1_STRING_data(x))
+```
+
+The cast to `const unsigned char *` makes the return type identical to the 1.1.0+ signature so callers compile cleanly without further casts.
+
+- [ ] **Step 3: Build to confirm the macro addition compiles**
+
+```bash
+make clean && perl Makefile.PL && make 2>&1 | grep -iE 'error|warning'
+```
+
+Expected: no errors (warnings about unused variables are pre-existing and acceptable; new warnings mean something is wrong).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add PKCS12.xs
+git commit -m "compat: add ASN1_STRING_get0_data macro for OpenSSL < 1.1.0"
+```
+
+---
+
+## Task 4: Fix `print_attribute()` — replace direct struct member access
+
+**Files:**
+- Modify: `PKCS12.xs:659-710` (the `switch (av->type)` block in `print_attribute()`)
+
+There are four `case` branches to fix. All follow the same pattern: replace `->length` with `ASN1_STRING_length()` and `->data` with `ASN1_STRING_get0_data()`.
+
+`get_hex()` and `hex_prin()` both take `unsigned char *` (non-const), so cast the return of `ASN1_STRING_get0_data()` there.
+
+### 4a — `V_ASN1_BMPSTRING`
+
+- [ ] **Step 1: Replace the two dereferences in the BMPSTRING case**
+
+Current code (lines 659-671):
+```c
+  case V_ASN1_BMPSTRING:
+    length = av->value.bmpstring->length;
+    if (length < 0 || length > (INT_MAX - 1))
+      croak("BMPSTRING attribute length out of range (got %d)", length);
+    value = OPENSSL_uni2asc(av->value.bmpstring->data, length);
+```
+
+Replace with:
+```c
+  case V_ASN1_BMPSTRING:
+    length = ASN1_STRING_length(av->value.bmpstring);
+    if (length < 0 || length > (INT_MAX - 1))
+      croak("BMPSTRING attribute length out of range (got %d)", length);
+    value = OPENSSL_uni2asc(ASN1_STRING_get0_data(av->value.bmpstring), length);
+```
+
+### 4b — `V_ASN1_UTF8STRING`
+
+- [ ] **Step 2: Replace the three dereferences in the UTF8STRING case**
+
+Current code (lines 673-685):
+```c
+  case V_ASN1_UTF8STRING:
+    length = av->value.utf8string->length;
+    if(*attribute != NULL) {
+      if (length < 0 || length > (INT_MAX - 1))
+        croak("UTF8STRING attribute length out of range (got %d)", length);
+      Renew(*attribute, (size_t)length + 1, char);
+      if (length)
+        memcpy(*attribute, av->value.utf8string->data, (size_t)length);
+      (*attribute)[length] = '\0';
+    } else {
+      BIO_printf(out, "%.*s\n", length, av->value.utf8string->data);
+    }
+    break;
+```
+
+Replace with:
+```c
+  case V_ASN1_UTF8STRING:
+    length = ASN1_STRING_length(av->value.utf8string);
+    if(*attribute != NULL) {
+      if (length < 0 || length > (INT_MAX - 1))
+        croak("UTF8STRING attribute length out of range (got %d)", length);
+      Renew(*attribute, (size_t)length + 1, char);
+      if (length)
+        memcpy(*attribute, ASN1_STRING_get0_data(av->value.utf8string), (size_t)length);
+      (*attribute)[length] = '\0';
+    } else {
+      BIO_printf(out, "%.*s\n", length, ASN1_STRING_get0_data(av->value.utf8string));
+    }
+    break;
+```
+
+### 4c — `V_ASN1_OCTET_STRING`
+
+- [ ] **Step 3: Replace the three dereferences in the OCTET_STRING case**
+
+Current code (lines 687-698):
+```c
+  case V_ASN1_OCTET_STRING:
+    length = av->value.octet_string->length;
+    if(*attribute != NULL) {
+      if (length < 0 || length > INT_MAX / 4)
+        croak("OCTET STRING attribute length out of range (got %d)", length);
+      Renew(*attribute, (size_t)length * 4, char);
+      get_hex(*attribute, av->value.octet_string->data, length);
+    } else {
+      hex_prin(out, av->value.octet_string->data, length);
+      BIO_printf(out, "\n");
+    }
+    break;
+```
+
+Replace with:
+```c
+  case V_ASN1_OCTET_STRING:
+    length = ASN1_STRING_length(av->value.octet_string);
+    if(*attribute != NULL) {
+      if (length < 0 || length > INT_MAX / 4)
+        croak("OCTET STRING attribute length out of range (got %d)", length);
+      Renew(*attribute, (size_t)length * 4, char);
+      get_hex(*attribute, (unsigned char *)ASN1_STRING_get0_data(av->value.octet_string), length);
+    } else {
+      hex_prin(out, (unsigned char *)ASN1_STRING_get0_data(av->value.octet_string), length);
+      BIO_printf(out, "\n");
+    }
+    break;
+```
+
+### 4d — `V_ASN1_BIT_STRING`
+
+- [ ] **Step 4: Replace the three dereferences in the BIT_STRING case**
+
+Current code (lines 700-711):
+```c
+  case V_ASN1_BIT_STRING:
+    length = av->value.bit_string->length;
+    if(*attribute != NULL) {
+      if (length < 0 || length > INT_MAX / 4)
+        croak("BIT STRING attribute length out of range (got %d)", length);
+      Renew(*attribute, (size_t)length * 4, char);
+      get_hex(*attribute, av->value.bit_string->data, length);
+    } else {
+      hex_prin(out, av->value.bit_string->data, length);
+      BIO_printf(out, "\n");
+    }
+    break;
+```
+
+Replace with:
+```c
+  case V_ASN1_BIT_STRING:
+    length = ASN1_STRING_length(av->value.bit_string);
+    if(*attribute != NULL) {
+      if (length < 0 || length > INT_MAX / 4)
+        croak("BIT STRING attribute length out of range (got %d)", length);
+      Renew(*attribute, (size_t)length * 4, char);
+      get_hex(*attribute, (unsigned char *)ASN1_STRING_get0_data(av->value.bit_string), length);
+    } else {
+      hex_prin(out, (unsigned char *)ASN1_STRING_get0_data(av->value.bit_string), length);
+      BIO_printf(out, "\n");
+    }
+    break;
+```
+
+- [ ] **Step 5: Build**
+
+```bash
+make clean && perl Makefile.PL && make 2>&1 | grep -iE 'error|warning'
+```
+
+Expected: no new errors or warnings.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+prove -lr -l -b -I inc t
+```
+
+Expected: same pass count as the Task 2 baseline.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add PKCS12.xs
+git commit -m "fix: use ASN1_STRING accessor API in print_attribute for OpenSSL 4.0 compat
+
+Direct ->data and ->length member access on ASN1_BMPSTRING, ASN1_UTF8STRING,
+ASN1_OCTET_STRING, and ASN1_BIT_STRING fails to compile under OpenSSL 4.0,
+which made struct asn1_string_st opaque. Replace with ASN1_STRING_length()
+and ASN1_STRING_get0_data() throughout print_attribute(). A compat macro
+maps ASN1_STRING_get0_data to ASN1_STRING_data for OpenSSL < 1.1.0.
+
+Fixes: https://github.com/dsully/perl-crypt-openssl-pkcs12/issues/60"
+```
+
+---
+
+## Task 5: Fix `print_attribs()` — replace direct `BUF_MEM` member access
+
+**Files:**
+- Modify: `PKCS12.xs:808-823` (the `attr_nid == NID_undef` branch in `print_attribs()`)
+
+**Why:** `BUF_MEM->length` and `BUF_MEM->data` are accessed directly after `BIO_get_mem_ptr()`. OpenSSL 4.0 may make `BUF_MEM` opaque in the same fashion. The documented pattern is `BIO_get_mem_data(bio, &ptr)`, which returns the length as a `long` and sets the pointer in one call — no `BUF_MEM*` needed at all.
+
+- [ ] **Step 1: Remove the `BUF_MEM*` variable and replace the access pattern**
+
+Current code (lines 808-823):
+```c
+            BIO *attr_bio;
+            BUF_MEM* bptr;
+
+            CHECK_OPEN_SSL(attr_bio = BIO_new(BIO_s_mem()));
+            i2a_ASN1_OBJECT(attr_bio, attr_obj);
+
+            CHECK_OPEN_SSL(BIO_flush(attr_bio) == 1);
+            BIO_get_mem_ptr(attr_bio, &bptr);
+
+            if (bptr->length > 0) {
+              if((hv_store(bag_hv,  bptr->data, bptr->length, newSVpvn(attribute_value, strlen(attribute_value)), 0)) == NULL)
+                croak("unable to add MAC to the hash");
+            }
+
+            CHECK_OPEN_SSL(BIO_set_close(attr_bio, BIO_CLOSE) == 1);
+            BIO_free(attr_bio);
+```
+
+Replace with:
+```c
+            BIO *attr_bio;
+            char *attr_key = NULL;
+            long attr_key_len;
+
+            CHECK_OPEN_SSL(attr_bio = BIO_new(BIO_s_mem()));
+            i2a_ASN1_OBJECT(attr_bio, attr_obj);
+
+            CHECK_OPEN_SSL(BIO_flush(attr_bio) == 1);
+            attr_key_len = BIO_get_mem_data(attr_bio, &attr_key);
+
+            if (attr_key_len > 0) {
+              if((hv_store(bag_hv, attr_key, (I32)attr_key_len, newSVpvn(attribute_value, strlen(attribute_value)), 0)) == NULL)
+                croak("unable to add MAC to the hash");
+            }
+
+            BIO_set_close(attr_bio, BIO_CLOSE);
+            BIO_free(attr_bio);
+```
+
+Note: `I32` is the Perl XS type for a 32-bit signed int — the `hv_store` key length parameter. The cast from `long` is safe because OID text representations are never more than a few hundred bytes.
+
+- [ ] **Step 2: Build**
+
+```bash
+make clean && perl Makefile.PL && make 2>&1 | grep -iE 'error|warning'
+```
+
+Expected: no new errors or warnings.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+prove -lr -l -b -I inc t
+```
+
+Expected: same pass count as the Task 2 baseline. The test `pkcs12-info-arbitrary-bag-attributes.t` exercises the `NID_undef` branch (the custom OID `1.2.3.4.5` attribute stored in secretbag and similar files).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add PKCS12.xs
+git commit -m "fix: replace BUF_MEM direct access with BIO_get_mem_data in print_attribs
+
+Avoids BUF_MEM struct member dereference, which may become opaque in future
+OpenSSL releases. BIO_get_mem_data() is the documented accessor for memory
+BIOs and works across all supported OpenSSL versions."
+```
+
+---
+
+## Task 6: Author-mode build check
+
+Run with `-Wall -Werror` enabled (the way CI builds on Linux) to catch any const-discard or implicit-conversion warnings introduced by the casts.
+
+- [ ] **Step 1: Clean and rebuild with author flags**
+
+```bash
+make clean && AUTHOR_TESTING=1 perl Makefile.PL && make 2>&1 | grep -iE 'error|warning'
+```
+
+Expected: no errors or new warnings. If you see a `discards 'const' qualifier` warning on any `(unsigned char *)ASN1_STRING_get0_data(...)` cast, change it to `(const unsigned char *)` in the corresponding `get_hex`/`hex_prin` call and update the function signature to accept `const unsigned char *` instead of `unsigned char *`.
+
+- [ ] **Step 2: Run the full test suite one final time**
+
+```bash
+prove -lr -l -b -I inc t
+```
+
+Expected: all tests pass.
+
+---
+
+## Task 7: Open the pull request
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/openssl-4-opaque-asn1
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --title "fix: OpenSSL 4.0 — use ASN1_STRING accessors instead of direct struct member access" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- OpenSSL 4.0 made `struct asn1_string_st` (backing type for `ASN1_BMPSTRING`, `ASN1_UTF8STRING`, `ASN1_OCTET_STRING`, `ASN1_BIT_STRING`) opaque, breaking direct `->data`/`->length` access in `print_attribute()` (Debian bug #1138300, issue #60).
+- Replaced all direct member dereferences with `ASN1_STRING_length()` and `ASN1_STRING_get0_data()`.
+- Added a compat macro `ASN1_STRING_get0_data` in the existing `#if OPENSSL_VERSION_NUMBER < 0x10100000L` block so the fix is unconditional — no per-call `#ifdef`.
+- Also replaced `BUF_MEM*`/`BIO_get_mem_ptr()` pattern in `print_attribs()` with `BIO_get_mem_data()`, the documented idiom that avoids opaque struct access.
+
+## Test plan
+
+- [ ] All existing tests pass on OpenSSL 3.x (`prove -lr -l -b -I inc t`)
+- [ ] Author-mode build (`AUTHOR_TESTING=1`) produces no new errors or warnings
+- [ ] CI green on Linux / macOS / Windows (Strawberry Perl) matrix
+- [ ] Closes #60 — Debian OpenSSL 4.0 migration build failure
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ BMPSTRING `->length`/`->data` → `ASN1_STRING_length()`/`ASN1_STRING_get0_data()` (Task 4a)
+- ✅ UTF8STRING same (Task 4b)
+- ✅ OCTET_STRING same (Task 4c)
+- ✅ BIT_STRING same (Task 4d)
+- ✅ Compat macro for OpenSSL < 1.1.0 (Task 3)
+- ✅ BUF_MEM opaque risk eliminated (Task 5)
+- ✅ Author-mode `-Wall -Werror` check (Task 6)
+- ✅ PR opened against `master` (Task 7)
+
+**Placeholder scan:** No TBDs or "similar to Task N" references — every step has exact code.
+
+**Type consistency:** `ASN1_STRING_get0_data` returns `const unsigned char *` everywhere; casts to `unsigned char *` are explicit where required by `get_hex`/`hex_prin`. `attr_key_len` is `long` (as returned by `BIO_get_mem_data`) and cast to `I32` only at the `hv_store` call site.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# test.sh
+
+set -e
+
+# Install dependencies once at the start
+echo "Installing Perl dependencies via Carton..."
+carton install
+
+test_openssl_version() {
+    local VERSION=$1
+    local PREFIX=$2
+
+    # Capture original values so they can be restored after each run
+    local _ORIG_OPENSSL_PREFIX="$OPENSSL_PREFIX"
+    local _ORIG_PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
+    local _ORIG_LDFLAGS="$LDFLAGS"
+    local _ORIG_CPPFLAGS="$CPPFLAGS"
+    local _ORIG_DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH"
+
+    echo "================================"
+    echo "Testing with OpenSSL $VERSION"
+    echo "================================"
+
+    export OPENSSL_PREFIX="$PREFIX"
+    export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$_ORIG_PKG_CONFIG_PATH"
+    export LDFLAGS="-L$PREFIX/lib"
+    export CPPFLAGS="-I$PREFIX/include"
+    export DYLD_LIBRARY_PATH="$PREFIX/lib:$_ORIG_DYLD_LIBRARY_PATH"
+
+    # Clean
+    make clean 2>/dev/null || true
+    rm -f Makefile.old
+
+    # Configure
+    carton exec perl Makefile.PL
+
+    # Verify version
+    echo -n "Detected OpenSSL version: "
+    grep "OPENSSL_PREFIX" Makefile || grep "INC.*openssl" Makefile | head -1
+
+    # Build
+    echo "Building..."
+    carton exec make
+
+    # Test
+    echo "Running tests..."
+    carton exec make test
+
+    echo "✓ OpenSSL $VERSION: SUCCESS"
+    echo ""
+
+    # Restore original environment so subsequent runs start from a clean state
+    export OPENSSL_PREFIX="$_ORIG_OPENSSL_PREFIX"
+    export PKG_CONFIG_PATH="$_ORIG_PKG_CONFIG_PATH"
+    export LDFLAGS="$_ORIG_LDFLAGS"
+    export CPPFLAGS="$_ORIG_CPPFLAGS"
+    export DYLD_LIBRARY_PATH="$_ORIG_DYLD_LIBRARY_PATH"
+}
+
+# Test OpenSSL 3.x
+test_openssl_version "3.x" "/opt/homebrew/opt/openssl@3"
+
+# Test OpenSSL 3.0 (adjust path as needed)
+test_openssl_version "3.0" "/opt/homebrew/opt/openssl@3.0"
+
+# Test OpenSSL 3.5 (adjust path as needed)
+test_openssl_version "3.5" "/opt/homebrew/opt/openssl@3.5"
+
+# Test OpenSSL 4.x (adjust path as needed)
+test_openssl_version "4.x" "/opt/homebrew/opt/openssl@4"  # or /usr/local/openssl-4.0.0
+
+echo "================================"
+echo "All tests completed successfully!"
+echo "================================"


### PR DESCRIPTION
## Summary

- OpenSSL 4.0 made `struct asn1_string_st` (backing type for `ASN1_BMPSTRING`, `ASN1_UTF8STRING`, `ASN1_OCTET_STRING`, `ASN1_BIT_STRING`) opaque, breaking direct `->data`/`->length` access in `print_attribute()` — Debian bug [#1138300](https://bugs.debian.org/1138300), closes #57, closes #60.
- Added a compat macro `ASN1_STRING_get0_data` in the existing `#if OPENSSL_VERSION_NUMBER < 0x10100000L` block so the replacement is unconditional — no per-call `#ifdef` required.
- Replaced all 10 direct member dereferences across the four ASN.1 string case branches with `ASN1_STRING_length()` and `ASN1_STRING_get0_data()`.
- Also replaced the `BUF_MEM*`/`BIO_get_mem_ptr()` pattern in `print_attribs()` with `BIO_get_mem_data()`, the documented accessor that avoids opaque struct access.
- Fixed const qualifier warnings on `X509_ATTRIBUTE_get0_object()` and `X509_ATTRIBUTE_get0_type()` return values (OpenSSL 4.0 tightened these to return `const` pointers).

## Commits

- `compat: add ASN1_STRING_get0_data macro for OpenSSL < 1.1.0`
- `fix: use ASN1_STRING accessor API in print_attribute for OpenSSL 4.0 compat`
- `fix: replace BUF_MEM direct access with BIO_get_mem_data in print_attribs`
- `style: cast BIO_set_close return to void for consistency`
- `fix: use CONST_ASN1_OBJECT and CONST_ASN1_TYPE for X509_ATTRIBUTE accessors`

## Test plan

- [x] All 357 existing tests pass on OpenSSL 3.x (`prove -lr -l -b -I inc t`)
- [ ] CI green on Linux (`-Wall -Werror` via `AUTHOR_TESTING=1`) / macOS / Windows (Strawberry Perl) matrix
- [ ] Closes #57 — print_attribute direct ASN1_STRING struct member access
- [ ] Closes #60 — Debian OpenSSL 4.0 migration build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)