### PR TITLE
Add zizmor security scanning and harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -12,9 +12,16 @@ on:
 env:
   CYGWIN_NOWINPATH: 1
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   perl:
-
+    name: Perl (cygwin)
     runs-on: windows-latest
 
     strategy:
@@ -31,10 +38,12 @@ jobs:
           git config --global core.eol lf
         shell: powershell
 
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
 
       - name: Set up Cygwin
-        uses: egor-tensin/setup-cygwin@v3
+        uses: egor-tensin/setup-cygwin@0c5b8b7b0f35a493f5b8c2687c5fd204c2628538 # v3
         with:
           platform: x64
           packages: make perl gcc-core gcc-g++ pkg-config libcrypt-devel libssl-devel libnsl-devel git curl

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -38,7 +38,8 @@ jobs:
           git config --global core.eol lf
         shell: powershell
 
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Cygwin
-        uses: egor-tensin/setup-cygwin@0c5b8b7b0f35a493f5b8c2687c5fd204c2628538 # v3
+        uses: egor-tensin/setup-cygwin@0c5b8b7b0f35a493f5b8c2687c5fd204c2628538 # v3.0.1
         with:
           platform: x64
           packages: make perl gcc-core gcc-g++ pkg-config libcrypt-devel libssl-devel libnsl-devel git curl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,10 +39,11 @@ jobs:
     container:
       image: perl:${{ matrix.perl-version }}
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
-      - name: uses install-with-cpanm
+      - name: Install dependencies with cpanm
         uses: perl-actions/install-with-cpanm@10d60f00b4073f484fc29d45bfbe2f776397ab3d # v1.7
         with:
           cpanfile: "cpanfile"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,8 +10,16 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   perl:
+    name: Perl (linux)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,9 +39,11 @@ jobs:
     container:
       image: perl:${{ matrix.perl-version }}
     steps:
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
       - name: uses install-with-cpanm
-        uses: perl-actions/install-with-cpanm@v1.7
+        uses: perl-actions/install-with-cpanm@10d60f00b4073f484fc29d45bfbe2f776397ab3d # v1.7
         with:
           cpanfile: "cpanfile"
           sudo: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,8 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
       # REF: https://github.com/actions/runner-images/tree/main/images/macos

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,8 +10,17 @@ on:
   pull_request:
     branches:
       - '*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   perl:
+    name: Perl (macos)
     # REF: https://github.com/actions/virtual-environments
     runs-on: macOS-latest
 
@@ -19,7 +28,9 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
       # REF: https://github.com/actions/runner-images/tree/main/images/macos
       # See link above, at the time of writing we get Perl 5.36.1 with macOS 13.5.1)
       - name: Set up Perl

--- a/.github/workflows/msys2-mingw.yml
+++ b/.github/workflows/msys2-mingw.yml
@@ -9,9 +9,17 @@ on:
   pull_request:
     branches:
       - '*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   perl:
-
+    name: Perl (msys2-mingw)
     runs-on: windows-latest
 
     strategy:
@@ -28,10 +36,12 @@ jobs:
           git config --global core.eol lf
         shell: powershell
 
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
 
       - name: Set up msys2
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           update: true
           install: >-

--- a/.github/workflows/msys2-mingw.yml
+++ b/.github/workflows/msys2-mingw.yml
@@ -36,7 +36,8 @@ jobs:
           git config --global core.eol lf
         shell: powershell
 
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/msys2-mingw.yml
+++ b/.github/workflows/msys2-mingw.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up msys2
-        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           update: true
           install: >-

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,9 +9,17 @@ on:
   pull_request:
     branches:
       - '*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   perl:
-
+    name: Perl (windows)
     runs-on: windows-latest
 
     strategy:
@@ -22,7 +30,9 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
 
       - name: Set up Perl
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install the latest version of uv
+      - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Run zizmor 🌈

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,47 @@
+name: zizmor
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+env:
+  ZIZMOR_VERSION: 1.26.1
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for uploading SARIF files
+      contents: read         # Needed to clone the repository
+      actions: read          # Needed for upload-sarif metadata
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - name: Run zizmor 🌈
+        run: uvx "zizmor@${ZIZMOR_VERSION}" --format=sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Optional: enables online audits
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
## Summary
- Adds a `zizmor` workflow that scans all GitHub Actions workflows on push/PR and uploads SARIF results to code scanning
- Fixes every finding zizmor raised against the existing platform workflows (cygwin, linux, macos, msys2-mingw, windows): pin all third-party actions to commit SHAs (with a human-readable version comment matching each pin), set `persist-credentials: false` on checkout, add least-privilege `permissions:` blocks, name every job and step (instead of falling back to the `uses:` reference), and add `concurrency:` groups to cancel superseded runs
- Adds `.github/dependabot.yml` scoped to the `github-actions` ecosystem, with major bumps grouped separately from minor/patch and a 7-day cooldown before PRs open

## Test plan
- [x] `zizmor .github/workflows/` reports zero findings under the default persona
- [x] All workflow YAML parses cleanly
- [x] Every pinned action SHA verified against its upstream tag (including peeling annotated tags), and comments corrected to reference the specific immutable release tag rather than a moving major alias where applicable
- [ ] CI runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)