### PR TITLE
fix: guard changepass against OpenSSL 3.x/4.x breakage, stop test crashes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,15 @@ Tests use pre-generated `.p12` files in `certs/`. Different cert files are used 
 
 ### OpenSSL Version Compatibility
 
-The codebase maintains compatibility across OpenSSL 1.0, 1.1, and 3.x via:
+The codebase maintains compatibility across OpenSSL 1.0, 1.1, 3.x, and 4.x via:
 - C preprocessor macros aliasing renamed/removed symbols for older versions
 - Runtime version checks using `Crypt::OpenSSL::Guess`'s `openssl_version()` in tests
-- Some features (e.g., `changepass`) are skipped on OpenSSL 3.x due to upstream limitations
+- `changepass` (`PKCS12_newpass()`) is a known-broken upstream API for PBES2-encrypted
+  PKCS12 files (the default on OpenSSL 3.x/4.x) — see
+  [openssl/openssl#19092](https://github.com/openssl/openssl/issues/19092) and
+  [#62](https://github.com/dsully/perl-crypt-openssl-pkcs12/issues/62). Only OpenSSL 1.x
+  is confirmed working; the test suite skips it everywhere else (`t/pkcs12.t`,
+  `t/pkcs12-string.t`, `t/pkcs12-from-scratch.t`)
 
 ## Release
 

--- a/PKCS12.pm
+++ b/PKCS12.pm
@@ -130,9 +130,15 @@ password, corrupted file, or OpenSSL error).
 Re-encrypts the PKCS12 structure with a new password. C<$old> is the current
 password; C<$new> is the replacement. Returns false on failure.
 
-B<Note:> Changing the PKCS12 password is not reliably supported on OpenSSL
-3.x; C<changepass()> may return false or fail silently. Consider
-re-creating the PKCS12 structure with C<create()> instead.
+B<Note:> Changing the PKCS12 password is not supported on OpenSSL 3.x or
+4.x for PBES2-encrypted files (the default OpenSSL uses for newly created
+PKCS12 files) — C<changepass()> will return false. This is a known
+upstream OpenSSL limitation
+(L<openssl/openssl#19092|https://github.com/openssl/openssl/issues/19092>),
+not specific to this module; only OpenSSL 1.x is confirmed to work. See
+L<https://github.com/dsully/perl-crypt-openssl-pkcs12/issues/62> for
+details. Consider re-creating the PKCS12 structure with C<create()>
+instead.
 
 =item * create( C<$cert>, C<$key>, C<$pass>, C<$output_file>, C<$friendly_name> )
 

--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -1206,7 +1206,11 @@ changepass(pkcs12, oldpwd = &PL_sv_undef, newpwd = &PL_sv_undef)
   }
 
   if (!(PKCS12_newpass(pkcs12, oldpwd_str, newpwd_str))) {
-    warn("PKCS12_newpass failed: %s", ssl_error(aTHX));
+    warn("PKCS12_newpass failed: %s\n"
+         "Note: PKCS12_newpass() cannot change the password on PBES2-encrypted "
+         "PKCS12 files, which OpenSSL 3.x/4.x use by default for newly created "
+         "files. This is a known upstream OpenSSL limitation, not specific to "
+         "this module: https://github.com/openssl/openssl/issues/19092", ssl_error(aTHX));
     RETVAL = &PL_sv_no;
   } else {
     RETVAL = &PL_sv_yes;

--- a/t/pkcs12-from-scratch.t
+++ b/t/pkcs12-from-scratch.t
@@ -116,16 +116,26 @@ ok($pkcs12->mac_ok($pass), 'Asserting mac');
 ok($pkcs12->as_string, 'Asserting PKCS12 as string');
 
 SKIP: {
-    # https://github.com/openssl/openssl/issues/19092
-    if ($major =~ /^3\./) {
-        skip("OpenSSL 3.x cannot change pkcs12 passwords", 3);
+    # PKCS12_newpass() is fundamentally broken for PBES2-encrypted PKCS12
+    # files (the default since OpenSSL 1.1/3.x): confirmed upstream at
+    # https://github.com/openssl/openssl/issues/19092. It also fails
+    # differently on 3.0 (ASN1 parse error) vs 3.5+/4.x (unknown pbe
+    # algorithm). Only OpenSSL 1.x is confirmed to work; see #62.
+    if ($major !~ /^1\./) {
+        skip("changepass unsupported on OpenSSL $major (see #62)", 3);
     } else {
         # try changing the password
-        ok($pkcs12->changepass($pass, 'foo'), 'Changing password');
+        my $changed = eval { $pkcs12->changepass($pass, 'foo') };
+        ok($changed, 'Changing password') or diag($@ || 'changepass returned false');
 
-        ok($pkcs12->mac_ok('foo'), 'Reasserting mac');
+        SKIP: {
+            skip('changepass failed, skipping dependent checks', 2) unless $changed;
 
-        ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+            my $verified = eval { $pkcs12->mac_ok('foo') };
+            ok($verified, 'Reasserting mac') or diag($@ || 'mac_ok returned false');
+
+            ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+        }
     }
 }
 # Try creating a PKCS12 file.

--- a/t/pkcs12-string.t
+++ b/t/pkcs12-string.t
@@ -102,16 +102,26 @@ ok($pkcs12->mac_ok($pass), 'Asserting mac');
 ok($pkcs12->as_string, 'Asserting PKCS12 as string');
 
 SKIP: {
-    # https://github.com/openssl/openssl/issues/19092
-    if ($major =~ /^3\./) {
-        skip("OpenSSL 3.x cannot change pkcs12 passwords", 3);
+    # PKCS12_newpass() is fundamentally broken for PBES2-encrypted PKCS12
+    # files (the default since OpenSSL 1.1/3.x): confirmed upstream at
+    # https://github.com/openssl/openssl/issues/19092. It also fails
+    # differently on 3.0 (ASN1 parse error) vs 3.5+/4.x (unknown pbe
+    # algorithm). Only OpenSSL 1.x is confirmed to work; see #62.
+    if ($major !~ /^1\./) {
+        skip("changepass unsupported on OpenSSL $major (see #62)", 3);
     } else {
         # try changing the password
-        ok($pkcs12->changepass($pass, 'foo'), 'Changing password');
+        my $changed = eval { $pkcs12->changepass($pass, 'foo') };
+        ok($changed, 'Changing password') or diag($@ || 'changepass returned false');
 
-        ok($pkcs12->mac_ok('foo'), 'Reasserting mac');
+        SKIP: {
+            skip('changepass failed, skipping dependent checks', 2) unless $changed;
 
-        ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+            my $verified = eval { $pkcs12->mac_ok('foo') };
+            ok($verified, 'Reasserting mac') or diag($@ || 'mac_ok returned false');
+
+            ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+        }
     }
 }
 # Try creating a PKCS12 file.

--- a/t/pkcs12.t
+++ b/t/pkcs12.t
@@ -44,16 +44,26 @@ ok($pkcs12->mac_ok($pass), 'Asserting mac');
 ok($pkcs12->as_string, 'Asserting PKCS12 as string');
 
 SKIP: {
-    # https://github.com/openssl/openssl/issues/19092
-    if ($major =~ /^3\./) {
-        skip("OpenSSL 3.x cannot change pkcs12 passwords", 3);
+    # PKCS12_newpass() is fundamentally broken for PBES2-encrypted PKCS12
+    # files (the default since OpenSSL 1.1/3.x): confirmed upstream at
+    # https://github.com/openssl/openssl/issues/19092. It also fails
+    # differently on 3.0 (ASN1 parse error) vs 3.5+/4.x (unknown pbe
+    # algorithm). Only OpenSSL 1.x is confirmed to work; see #62.
+    if ($major !~ /^1\./) {
+        skip("changepass unsupported on OpenSSL $major (see #62)", 3);
     } else {
         # try changing the password
-        ok($pkcs12->changepass($pass, 'foo'), 'Changing password');
+        my $changed = eval { $pkcs12->changepass($pass, 'foo') };
+        ok($changed, 'Changing password') or diag($@ || 'changepass returned false');
 
-        ok($pkcs12->mac_ok('foo'), 'Reasserting mac');
+        SKIP: {
+            skip('changepass failed, skipping dependent checks', 2) unless $changed;
 
-        ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+            my $verified = eval { $pkcs12->mac_ok('foo') };
+            ok($verified, 'Reasserting mac') or diag($@ || 'mac_ok returned false');
+
+            ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`PKCS12_newpass()` is fundamentally broken upstream for PBES2-encrypted PKCS12 files ([openssl/openssl#19092](https://github.com/openssl/openssl/issues/19092)), which OpenSSL 3.x/4.x use by default for newly created files. This was investigated in depth in #62: only OpenSSL 1.x is confirmed to actually work; 3.0 fails with an ASN1 parse error, 3.5+/4.x fail with `unknown pbe algorithm ... hmacWithSHA256`.

A real fix would mean reimplementing `changepass()` as extract-and-rebuild via `create()`, but `create()`/`create_as_string()` only support a single private key + single leaf cert + flat CA chain (via `PKCS12_create()`), so that path would silently drop fidelity for any PKCS12 file with multiple keys, secret bags, or custom bag attributes — out of scope for this pre-release. Scoped this down to: stop the crash, make the skip guard accurate, document the limitation clearly.

## Changes

- **Test crash fix**: the skip guard in `t/pkcs12.t`, `t/pkcs12-string.t`, `t/pkcs12-from-scratch.t` was `if ($major =~ /^3\./)`, which let OpenSSL 4.x slip through the skip and attempt `changepass()` for real. The subsequent unguarded `mac_ok('foo')` call legitimately `croak()`s on the resulting verification failure, and since it wasn't wrapped in `eval`, that killed the whole test process (`Bad plan` TAP errors, exit 29/255).
- Skip guard now triggers whenever `$major !~ /^1\./` (i.e. everywhere except the one confirmed-working major), and the risky calls are wrapped so any future regression degrades to a normal test failure instead of a process abort.
- `changepass()`'s `warn()` on failure now explains the known upstream limitation instead of just dumping the raw OpenSSL error.
- Documented the limitation in `PKCS12.pm` POD (`changepass` section) and `CLAUDE.md`.

## Test plan

- [x] Full test suite passes locally against real local builds of OpenSSL 1.1.1w, 3.0.21, 3.5.7, and 4.0.1 (Homebrew `openssl@1.1`/`@3.0`/`@3.5`/`@4`) — no crashes on any version, `changepass` genuinely runs and passes on 1.1.1w, cleanly skips elsewhere.
- [x] CI green across the platform matrix

Closes the test-suite-crash portion of #62; the underlying `changepass()` unsupported-on-3.x/4.x limitation remains open and documented, not fixed (see issue for why a full fix is out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)