### PR TITLE
fix: address Copilot review feedback on PR #76

### DIFF
--- a/PKCS12.xs
+++ b/PKCS12.xs
@@ -1210,7 +1210,7 @@ changepass(pkcs12, oldpwd = &PL_sv_undef, newpwd = &PL_sv_undef)
          "Note: PKCS12_newpass() cannot change the password on PBES2-encrypted "
          "PKCS12 files, which OpenSSL 3.x/4.x use by default for newly created "
          "files. This is a known upstream OpenSSL limitation, not specific to "
-         "this module: https://github.com/openssl/openssl/issues/19092", ssl_error(aTHX));
+         "this module: https://github.com/openssl/openssl/issues/19092\n", ssl_error(aTHX));
     RETVAL = &PL_sv_no;
   } else {
     RETVAL = &PL_sv_yes;

--- a/t/pkcs12-from-scratch.t
+++ b/t/pkcs12-from-scratch.t
@@ -125,16 +125,20 @@ SKIP: {
         skip("changepass unsupported on OpenSSL $major (see #62)", 3);
     } else {
         # try changing the password
+        local $@;
         my $changed = eval { $pkcs12->changepass($pass, 'foo') };
         ok($changed, 'Changing password') or diag($@ || 'changepass returned false');
 
         SKIP: {
             skip('changepass failed, skipping dependent checks', 2) unless $changed;
 
+            local $@;
             my $verified = eval { $pkcs12->mac_ok('foo') };
             ok($verified, 'Reasserting mac') or diag($@ || 'mac_ok returned false');
 
-            ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+            local $@;
+            my $changed_again = eval { $pkcs12->changepass('foo', $pass) };
+            ok($changed_again, 'Changing password again') or diag($@ || 'changepass returned false');
         }
     }
 }

--- a/t/pkcs12-string.t
+++ b/t/pkcs12-string.t
@@ -111,16 +111,20 @@ SKIP: {
         skip("changepass unsupported on OpenSSL $major (see #62)", 3);
     } else {
         # try changing the password
+        local $@;
         my $changed = eval { $pkcs12->changepass($pass, 'foo') };
         ok($changed, 'Changing password') or diag($@ || 'changepass returned false');
 
         SKIP: {
             skip('changepass failed, skipping dependent checks', 2) unless $changed;
 
+            local $@;
             my $verified = eval { $pkcs12->mac_ok('foo') };
             ok($verified, 'Reasserting mac') or diag($@ || 'mac_ok returned false');
 
-            ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+            local $@;
+            my $changed_again = eval { $pkcs12->changepass('foo', $pass) };
+            ok($changed_again, 'Changing password again') or diag($@ || 'changepass returned false');
         }
     }
 }

--- a/t/pkcs12.t
+++ b/t/pkcs12.t
@@ -53,16 +53,20 @@ SKIP: {
         skip("changepass unsupported on OpenSSL $major (see #62)", 3);
     } else {
         # try changing the password
+        local $@;
         my $changed = eval { $pkcs12->changepass($pass, 'foo') };
         ok($changed, 'Changing password') or diag($@ || 'changepass returned false');
 
         SKIP: {
             skip('changepass failed, skipping dependent checks', 2) unless $changed;
 
+            local $@;
             my $verified = eval { $pkcs12->mac_ok('foo') };
             ok($verified, 'Reasserting mac') or diag($@ || 'mac_ok returned false');
 
-            ok($pkcs12->changepass('foo', $pass), 'Changing password again');
+            local $@;
+            my $changed_again = eval { $pkcs12->changepass('foo', $pass) };
+            ok($changed_again, 'Changing password again') or diag($@ || 'changepass returned false');
         }
     }
 }


### PR DESCRIPTION
Follow-up to #76 (already merged) — Copilot's review landed after merge but all 4 comments were valid, so fixing them here.

- Guard the final `changepass()` call in the SKIP block too (`t/pkcs12.t`, `t/pkcs12-string.t`, `t/pkcs12-from-scratch.t`), for consistency with the other two calls in the same block — the whole point of #76 was crash-proofing this block, and leaving one call unguarded undercut that.
- `local $@` before each `eval`, the standard defensive idiom, so `diag()` can't show a stale exception from unrelated code even in edge cases (destructors running eval during scope unwind, etc).
- Terminate `changepass()`'s `warn()` message with `\n` so Perl doesn't append `at PKCS12.xs line N.` onto the URL, which was making the multi-line message harder to read.

## Test plan

- [x] Full test suite passes against real local builds of OpenSSL 1.1.1w, 3.0.21, 3.5.7, and 4.0.1
- [x] Verified the warn() message no longer has the location suffix glued onto the URL line